### PR TITLE
Fix macOS conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `hcdl` Changelog
 
+## v0.10.3
+
+  - Fix macOS conditional compilation
+
 ## v0.10.2
 
   - Add support for generating shell tab completions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hcdl"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hcdl"
 description = "Easily download and update HashiCorp tools"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["David O'Rourke <david.orourke@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub const DEFAULT_OS: &str = "freebsd";
 #[cfg(target_os = "linux")]
 pub const DEFAULT_OS: &str = "linux";
 
-#[cfg(target_os = "mac_os")]
+#[cfg(target_os = "macos")]
 pub const DEFAULT_OS: &str = "darwin";
 
 #[cfg(target_os = "openbsd")]


### PR DESCRIPTION
This fixes a broken macOS conditional discovered while researching a breakage in Rust between syn/proc-macro2/tokio-macros.