### PR TITLE
Take care of cargo clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,10 +74,7 @@ const NO_COLOR: &str = "NO_COLOR";
 
 // Checks the environment to see if NO_COLOR is in use.
 pub fn no_color() -> bool {
-    match env::var_os(NO_COLOR) {
-        Some(_) => true,
-        None    => false,
-    }
+    env::var_os(NO_COLOR).is_some()
 }
 
 // Ensure that the installation dir exists and is a directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! hcdl: Easily update Hashicorp tools
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
+#![allow(clippy::redundant_field_names)]
 use anyhow::Result;
 use std::path::Path;
 use std::process::exit;


### PR DESCRIPTION
This PR:

  - Fixes a simple Cargo clippy removing an necessary match
  - Allow redundant field names on structs