### PR TITLE
Move various functionality under lib.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v0.13.0
 
-  - Bump MSRV to 1.65.0
+  - Bump MSRV to 1.68.2
   - Bump dependencies
+  - Moved lots of functionality under `lib.rs`
 
 ## v0.12.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror",
  "tokio",
  "url",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/phyber/hcdl"
 repository = "https://github.com/phyber/hcdl"
-rust-version = "1.65.0"
+rust-version = "1.68.2"
 resolver = "2"
 categories = [
     "command-line-utilities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ pgp = "0.10"
 serde_json = "1.0"
 sha2 = "0.10"
 tempfile = "3.6"
+thiserror = "1.0"
 
 [dependencies.clap]
 version = "4.3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,14 @@ exclude = [
     ".github",
 ]
 
+[[bin]]
+name = "hcdl"
+path = "src/main.rs"
+
+[lib]
+name = "hcdl"
+path = "src/lib.rs"
+
 [features]
 default = [
     "embed_gpg_key",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 `hcdl` is available for install from [crates.io] if you have a stable [Rust]
-toolchain of at least v1.65.0 installed.
+toolchain of at least v1.68.2 installed.
 
 This can be done with the standard Cargo install command:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,7 @@ fn is_valid_install_dir(s: &str) -> Result<PathBuf, String> {
     Ok(path.to_path_buf())
 }
 
+#[allow(clippy::too_many_lines)]
 fn create_app() -> Command {
     let app = Command::new(crate_name!())
         .version(crate_version!())

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,9 +12,15 @@ use std::io::prelude::*;
 use std::io::BufWriter;
 use url::Url;
 
-mod build;
-mod config;
-mod product_version;
+/// Re-export of `build`.
+pub mod build;
+
+/// Re-export of `config`.
+pub mod config;
+
+/// Re-export of `product_version`.
+pub mod product_version;
+
 pub use config::ClientConfig;
 use product_version::ProductVersion;
 
@@ -65,7 +71,7 @@ impl Client {
     /// Errors if:
     ///   - Failing to parse the created checkpoint URL
     ///   - Failing to get the product version
-    ///   - Failing to create a [`ProductVersion`]
+    ///   - Failing to create a [`crate::client::product_version::ProductVersion`]
     pub async fn check_version(&self, product: &str) -> Result<ProductVersion> {
         let url = format!(
             "{api}/{product}/latest",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,11 +1,13 @@
 // client: HTTP client and associated methods
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
-use crate::progressbar::ProgressBarBuilder;
-use crate::shasums::Shasums;
-use crate::signature::Signature;
-use crate::tmpfile::TmpFile;
-use super::error::ClientError;
+use crate::{
+    error::ClientError,
+    progressbar::ProgressBarBuilder,
+    shasums::Shasums,
+    signature::Signature,
+    tmpfile::TmpFile,
+};
 use bytes::Bytes;
 use reqwest::Response;
 use std::io::prelude::*;

--- a/src/client.rs
+++ b/src/client.rs
@@ -67,12 +67,9 @@ impl Client {
     ///   - Failing to get the product version
     ///   - Failing to create a [`ProductVersion`]
     pub async fn check_version(&self, product: &str) -> Result<ProductVersion> {
-        // We to_string here for the test scenario.
-        #![allow(clippy::to_string_in_format_args)]
         let url = format!(
             "{api}/{product}/latest",
             api = self.api_url,
-            product = product,
         );
 
         let url = Url::parse(&url)?;
@@ -206,13 +203,9 @@ impl Client {
         product: &str,
         version: &str,
     ) -> Result<ProductVersion> {
-        // We to_string here for the test scenario.
-        #![allow(clippy::to_string_in_format_args)]
         let url = format!(
             "{api}/{product}/{version}",
             api = self.api_url,
-            product = product,
-            version = version,
         );
 
         let url = Url::parse(&url)?;
@@ -255,7 +248,7 @@ mod tests {
 
     // Builds up the path to the test file
     fn data_path(filename: &str) -> String {
-        format!("{}{}", TEST_DATA_DIR, filename)
+        format!("{TEST_DATA_DIR}{filename}")
     }
 
     fn read_file_bytes(path: &PathBuf) -> Bytes {
@@ -317,7 +310,7 @@ mod tests {
     async fn test_get_bytes() {
         let mut server = mockito::Server::new_async().await;
         let server_url = server.url();
-        let url        = Url::parse(&format!("{}/test.txt", server_url)).unwrap();
+        let url        = Url::parse(&format!("{server_url}/test.txt")).unwrap();
         let expected   = "Test text\n";
         let data       = data_path("test.txt");
 
@@ -351,22 +344,22 @@ mod tests {
             name:              "terraform".into(),
             timestamp_created: DateTime::<Utc>::from_str("2020-05-27T16:55:35.000Z").unwrap(),
             timestamp_updated: DateTime::<Utc>::from_str("2020-05-27T16:55:35.000Z").unwrap(),
-            url_shasums:       Url::parse(&format!("{}/terraform/0.12.26/terraform_0.12.26_SHA256SUMS", server_url)).unwrap(),
+            url_shasums:       Url::parse(&format!("{server_url}/terraform/0.12.26/terraform_0.12.26_SHA256SUMS")).unwrap(),
             version:           "0.12.26".into(),
             builds:            vec![
                 Build {
                     arch: "amd64".into(),
                     os:   "freebsd".into(),
-                    url:  Url::parse(&format!("{}/terraform/0.12.26/terraform_0.12.26_freebsd_amd64.zip", server_url)).unwrap(),
+                    url:  Url::parse(&format!("{server_url}/terraform/0.12.26/terraform_0.12.26_freebsd_amd64.zip")).unwrap(),
                 },
                 Build {
                     arch: "amd64".into(),
                     os:   "linux".into(),
-                    url:  Url::parse(&format!("{}/terraform/0.12.26/terraform_0.12.26_linux_amd64.zip", server_url)).unwrap(),
+                    url:  Url::parse(&format!("{server_url}/terraform/0.12.26/terraform_0.12.26_linux_amd64.zip")).unwrap(),
                 },
             ],
             url_shasums_signatures: vec![
-                Url::parse(&format!("{}/terraform/0.12.26/terraform_0.12.26_SHA256SUMS.sig", server_url)).unwrap(),
+                Url::parse(&format!("{server_url}/terraform/0.12.26/terraform_0.12.26_SHA256SUMS.sig")).unwrap(),
             ],
         };
 
@@ -391,7 +384,7 @@ mod tests {
     async fn test_get_text() {
         let mut server = mockito::Server::new_async().await;
         let server_url = server.url();
-        let url        = Url::parse(&format!("{}/test.txt", server_url)).unwrap();
+        let url        = Url::parse(&format!("{server_url}/test.txt")).unwrap();
         let expected   = Bytes::from("Test text\n");
         let data       = data_path("test.txt");
 

--- a/src/client/build.rs
+++ b/src/client/build.rs
@@ -4,10 +4,15 @@
 use serde::Deserialize;
 use url::Url;
 
-// Represents a single build of a HashiCorp product
+/// Represents a single build of a [HashiCorp](https://hashicorp.io) product.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct Build {
+    /// The `arch` of the build.
     pub arch: String,
-    pub os:   String,
-    pub url:  Url,
+
+    /// The `os` of the build.
+    pub os: String,
+
+    /// The [`Url`] where the build can be found.
+    pub url: Url,
 }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -1,20 +1,32 @@
 // Client configuration
+
+/// [`ClientConfig`] is a configuration for [`Client`].
 #[derive(Debug, Default)]
 pub struct ClientConfig {
+    /// Control the output of colour in the crate messages and progress bars.
     pub no_color: bool,
+
+    /// Controls the output of text in the crate.
     pub quiet: bool,
 }
 
 impl ClientConfig {
+    /// Create a new [`ClientConfig`] with the default settings.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// `no_color` controls the output of colours in the various output of the
+    /// crate.
+    #[must_use]
     pub fn no_color(mut self, no_color: bool) -> Self {
         self.no_color = no_color;
         self
     }
 
+    /// `quiet` controls the various text output of the crate.
+    #[must_use]
     pub fn quiet(mut self, quiet: bool) -> Self {
         self.quiet = quiet;
         self

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -1,6 +1,6 @@
 // Client configuration
 
-/// [`ClientConfig`] is a configuration for [`Client`].
+/// [`ClientConfig`] is a configuration for [`crate::client::Client`].
 #[derive(Debug, Default)]
 pub struct ClientConfig {
     /// Control the output of colour in the crate messages and progress bars.

--- a/src/client/product_version.rs
+++ b/src/client/product_version.rs
@@ -12,21 +12,33 @@ use serde::{
 };
 use std::fmt;
 use std::str::FromStr;
-use super::build::Build;
 use url::Url;
 
-// Represents a single version of a HashiCorp product
+pub use super::build::Build;
+
+/// Represents a single version of a [HashiCorp](https://hashicorp.io) product.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct ProductVersion {
-    pub builds:                 Vec<Build>,
-    pub name:                   String,
-    pub url_shasums:            Url,
-    pub url_shasums_signatures: Vec<Url>,
-    pub version:                String,
+    /// A `Vec` of [`Build`] for the [`ProductVersion`].
+    pub builds: Vec<Build>,
 
+    /// The name of the product.
+    pub name: String,
+
+    /// The [`Url`] that the product shasums can be found at.
+    pub url_shasums: Url,
+
+    /// The [`Url`] that the product's shasums signature can be found at.
+    pub url_shasums_signatures: Vec<Url>,
+
+    /// The version number of the product.
+    pub version: String,
+
+    /// A timestamp representing when the product version was created.
     #[serde(deserialize_with = "deserialize_from_str")]
     pub timestamp_created: DateTime<Utc>,
 
+    /// A timestamp representing when the product version was updated.
     #[serde(deserialize_with = "deserialize_from_str")]
     pub timestamp_updated: DateTime<Utc>,
 }
@@ -42,7 +54,7 @@ where
 }
 
 impl ProductVersion {
-    // Pull a specific build out of the product version builds.
+    /// Pull a specific [`Build`] out of the [`ProductVersion`] `builds`.
     pub fn build(&self, arch: &str, os: &str) -> Option<&Build> {
         let filtered: Vec<&Build> = self.builds
             .iter()
@@ -57,12 +69,12 @@ impl ProductVersion {
         }
     }
 
-    // Create and return the shasums signature URL.
+    /// Create and return the shasums signature URL.
     pub fn shasums_signature_url(&self) -> Url {
         self.url_shasums_signatures.first().unwrap().clone()
     }
 
-    // Create and return the shasums URL.
+    /// Create and return the shasums URL.
     pub fn shasums_url(&self) -> Url {
         self.url_shasums.clone()
     }

--- a/src/client/product_version.rs
+++ b/src/client/product_version.rs
@@ -55,6 +55,7 @@ where
 
 impl ProductVersion {
     /// Pull a specific [`Build`] out of the [`ProductVersion`] `builds`.
+    #[must_use]
     pub fn build(&self, arch: &str, os: &str) -> Option<&Build> {
         let filtered: Vec<&Build> = self.builds
             .iter()
@@ -70,11 +71,18 @@ impl ProductVersion {
     }
 
     /// Create and return the shasums signature URL.
+    ///
+    /// # Panics
+    ///
+    /// This function could panic if there are no signature URLs returned by
+    /// the API.
+    #[must_use]
     pub fn shasums_signature_url(&self) -> Url {
         self.url_shasums_signatures.first().unwrap().clone()
     }
 
     /// Create and return the shasums URL.
+    #[must_use]
     pub fn shasums_url(&self) -> Url {
         self.url_shasums.clone()
     }

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -41,7 +41,7 @@ where
     let result = hasher.finalize();
 
     if result != expected {
-        return Err(Crc32Error::UnexpectedCrc32(expected, result));
+        return Err(Crc32Error::UnexpectedCrc32(result, expected));
     }
 
     Ok(())
@@ -63,7 +63,7 @@ mod tests {
 
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Error CRC32: Expected: 0x00000000, Got: 0x891bc0e8",
+            "unexpected crc32: 0x891bc0e8, wanted: 0x00000000",
         );
     }
 

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,9 +1,6 @@
 // crc32: Handle checking CRC32 of a given file against the expected CRC32.
 #![forbid(unsafe_code)]
-use anyhow::{
-    anyhow,
-    Result,
-};
+use super::error::Crc32Error;
 use crc32fast::Hasher;
 use std::fs::File;
 use std::io::{
@@ -23,7 +20,7 @@ const BUFFER_SIZE: usize = 256 * 1_024;
 ///   - Failing to open the given `path`
 ///   - Failing to read from the given `path`
 ///   - If the CRC32 of the given `path` doesn't match the `expected` value
-pub fn check<P>(path: P, expected: u32) -> Result<()>
+pub fn check<P>(path: P, expected: u32) -> Result<(), Crc32Error>
 where
     P: AsRef<Path>,
 {
@@ -44,13 +41,7 @@ where
     let result = hasher.finalize();
 
     if result != expected {
-        let msg = anyhow!(
-            "Error CRC32: Expected: {:#010x}, Got: {:#010x}",
-            expected,
-            result,
-        );
-
-        return Err(msg);
+        return Err(Crc32Error::UnexpectedCrc32(expected, result));
     }
 
     Ok(())

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -15,7 +15,14 @@ use std::path::Path;
 // Buffer size, 256KiB
 const BUFFER_SIZE: usize = 256 * 1_024;
 
-// Check the given `path`'s CRC32 against the `expected` CRC32.
+/// Check the given `path`'s CRC32 against the `expected` CRC32.
+///
+/// # Errors
+///
+/// Errors if:
+///   - Failing to open the given `path`
+///   - Failing to read from the given `path`
+///   - If the CRC32 of the given `path` doesn't match the `expected` value
 pub fn check<P>(path: P, expected: u32) -> Result<()>
 where
     P: AsRef<Path>,

--- a/src/crc32.rs
+++ b/src/crc32.rs
@@ -1,6 +1,6 @@
 // crc32: Handle checking CRC32 of a given file against the expected CRC32.
 #![forbid(unsafe_code)]
-use super::error::Crc32Error;
+use crate::error::Crc32Error;
 use crc32fast::Hasher;
 use std::fs::File;
 use std::io::{
@@ -20,6 +20,33 @@ const BUFFER_SIZE: usize = 256 * 1_024;
 ///   - Failing to open the given `path`
 ///   - Failing to read from the given `path`
 ///   - If the CRC32 of the given `path` doesn't match the `expected` value
+///
+/// # Examples
+///
+/// Check that the CRC32 of the crate's test-data file is correct.
+///
+/// ```
+/// use hcdl::crc32;
+///
+/// let path = concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/test.txt");
+/// let result = crc32::check(path, 0x891bc0e8);
+///
+/// assert!(result.is_ok());
+/// ```
+///
+/// The CRC32 was not what was expected.
+///
+/// ```
+/// use hcdl::{
+///     crc32,
+///     error::Crc32Error,
+/// };
+///
+/// let path = concat!(env!("CARGO_MANIFEST_DIR"), "/test-data/test.txt");
+/// let result = crc32::check(path, 0x12345678);
+///
+/// assert!(matches!(result.unwrap_err(), Crc32Error::UnexpectedCrc32(_, _)));
+/// ```
 pub fn check<P>(path: P, expected: u32) -> Result<(), Crc32Error>
 where
     P: AsRef<Path>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,3 +82,11 @@ pub enum SignatureError {
     #[error("couldn't verify signature")]
     Verification,
 }
+
+/// Errors encountered in the [`tmpfile`] module.
+#[derive(Debug, Error)]
+pub enum TmpFileError {
+    /// Returned if IO errors are encountered.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,55 @@
+// Library errors.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors encountered in the [`crc32`] module.
+#[derive(Debug, Error)]
+pub enum Crc32Error {
+    /// Returned if there's an IO error while calculating the CRC32 for the
+    /// extracted file.
+    #[error("io error")]
+    IoError(#[from] std::io::Error),
+
+    /// Returned if there's a problem with the calculated CRC32 for the
+    /// extracted file.
+    #[error("unexpected crc32. expected: {0:#010x}, got: {1:#010x}")]
+    UnexpectedCrc32(u32, u32),
+}
+
+/// Errors encountered in the [`install`] module.
+#[derive(Debug, Error)]
+pub enum InstallError {
+    /// Returned if there's an error while calculating the CRC32 for the
+    /// installed file.
+    #[error("crc32 error")]
+    Crc32(#[from] Crc32Error),
+
+    // Could not find suitable install-dir. Consider passing --install-dir to
+    // manually specify.
+    /// Returned if there's no executable directory.
+    #[error("no executable dir")]
+    NoExecutableDir,
+
+    /// Returned if the installation path is not a directory.
+    #[error("install: destination '{0}' is not a directory")]
+    NoInstallDir(PathBuf),
+
+    /// Returned if there's an error while persisting the tempfile to it's
+    /// proper destination.
+    #[error("error persisting file")]
+    PathPersist(#[from] tempfile::PathPersistError),
+
+    /// Returned if there's an error while setting the installed file's
+    /// permissions.
+    #[error("set permissions error")]
+    SetPermissions(#[from] std::io::Error),
+
+    /// Returned if there's an error while getting the zip file basename.
+    #[error("couldn't get zip file basename from '{0}'")]
+    ZipFileBasename(String),
+
+    /// Returned if there's an error while getting the zip file index.
+    #[error("zip index error")]
+    ZipIndex(#[from] zip::result::ZipError),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 // Library errors.
-
 use std::path::PathBuf;
 use thiserror::Error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,12 +8,12 @@ use thiserror::Error;
 pub enum Crc32Error {
     /// Returned if there's an IO error while calculating the CRC32 for the
     /// extracted file.
-    #[error("io error")]
+    #[error(transparent)]
     IoError(#[from] std::io::Error),
 
     /// Returned if there's a problem with the calculated CRC32 for the
     /// extracted file.
-    #[error("unexpected crc32. expected: {0:#010x}, got: {1:#010x}")]
+    #[error("unexpected crc32: {0:#010x}, wanted: {1:#010x}")]
     UnexpectedCrc32(u32, u32),
 }
 
@@ -77,4 +77,8 @@ pub enum SignatureError {
     /// Returned when the shasum signatures couldn't be verified.
     #[error(transparent)]
     Pgp(#[from] pgp::errors::Error),
+
+    /// Returned when the signature couldn't be verified.
+    #[error("couldn't verify signature")]
+    Verification,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,51 @@
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Errors encountered in the [`client`] module.
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// Returned when encountering an error building the [`Client`].
+    #[error("couldn't build http client")]
+    ClientBuilder,
+
+    /// Returned if there's an error downloading a chunk of content.
+    #[error("couldn't download chunk of content")]
+    Chunk,
+
+    /// Returned when there's an error getting a [`Url`].
+    #[error("couldn't get url '{0}'")]
+    Get(url::Url),
+
+    /// Returned if there's an error getting the [`Bytes`] from a GET request.
+    #[error("couldn't get bytes from get request")]
+    GetBytes,
+
+    /// Returned if there's an error getting a [`String`] from a GET request.
+    #[error("couldn't get text from get request")]
+    GetText,
+
+    /// Returned if there's an IO error while downloading content.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    /// Returned if there's an error parsing the [`ProductVersion`].
+    #[error("couldn't parse product version")]
+    ProductVersion,
+
+    /// Returned when there's an error getting a [`Signature`] for the
+    /// [`ProductVersion`].
+    #[error(transparent)]
+    Signature(#[from] SignatureError),
+
+    /// Returned if there's [`TmpFile`] error while downloading content.
+    #[error(transparent)]
+    TmpFile(#[from] TmpFileError),
+
+    /// Returned if there's an error parsing a [`Url`].
+    #[error("couldn't parse {0} url")]
+    Url(&'static str),
+}
+
 /// Errors encountered in the [`crc32`] module.
 #[derive(Debug, Error)]
 pub enum Crc32Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,3 +53,28 @@ pub enum InstallError {
     #[error("zip index error")]
     ZipIndex(#[from] zip::result::ZipError),
 }
+
+/// Errors encountered in the [`signature`] module.
+#[derive(Debug, Error)]
+pub enum SignatureError {
+    /// Returned if the GPG key path does not exist or is not a file.
+    #[error("gpg key file '{0}' does not exist or is not a file")]
+    GpgKey(PathBuf),
+
+    /// Returned when there's an IO error dealing with signature data.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    /// Returned if there's no XDG shared data directory returned.
+    #[error("couldn't find shared data directory")]
+    NoSharedDataDir,
+
+    /// Returned when the XDG shared data path returned does not exist or is
+    /// not a directory.
+    #[error("data directory '{0}' does not exist or is not a directory")]
+    NoSharedDataDirExists(PathBuf),
+
+    /// Returned when the shasum signatures couldn't be verified.
+    #[error(transparent)]
+    Pgp(#[from] pgp::errors::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,22 @@ pub enum InstallError {
     ZipIndex(#[from] zip::result::ZipError),
 }
 
+/// Errors encountered in the [`shasums`] module.
+#[derive(Debug, Error)]
+pub enum ShasumsError {
+    /// Returned if there's an error while calculating the shasum for the file.
+    #[error("io error while hashing file")]
+    Hashing,
+
+    /// Returned when the shasum for a file could not be found.
+    #[error("couldn't find shasum for {0}")]
+    NoShasumForFile(String),
+
+    /// Returned if there's a [`TmpFileError`] while hashing the file.
+    #[error(transparent)]
+    TmpFile(#[from] TmpFileError),
+}
+
 /// Errors encountered in the [`signature`] module.
 #[derive(Debug, Error)]
 pub enum SignatureError {

--- a/src/install.rs
+++ b/src/install.rs
@@ -103,8 +103,8 @@ where
 {
     if !dir.is_dir() {
         let err = anyhow!(
-            "install: Destination '{}' is not a directory",
-            dir.display(),
+            "install: Destination '{path}' is not a directory",
+            path = dir.display(),
         );
 
         return Err(err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,32 @@
+//! hcdl: Easily update Hashicorp tools
+#![forbid(unsafe_code)]
+#![forbid(missing_docs)]
+#![allow(clippy::module_name_repetitions)]
+#![allow(clippy::redundant_field_names)]
+
+/// Client for downloading products.
+pub mod client;
+
+/// Handle checking the CRC32 of files extracted from zipfiles.
+pub mod crc32;
+
+/// Handle extracting and installing downloaded product.
+pub mod install;
+
+/// Various output messages.
+pub mod messages;
+
+/// List of [HashiCorp](https://www.hashicorp.com/) products.
+pub mod products;
+
+/// Handle drawing progress bars during download and install.
+pub mod progressbar;
+
+/// Handle file checksums.
+pub mod shasums;
+
+/// Handles for checking file signatures.
+pub mod signature;
+
+/// Wrapper for handling a tempfile.
+pub mod tmpfile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub mod client;
 /// Handle checking the CRC32 of files extracted from zipfiles.
 pub mod crc32;
 
+/// This module contains the error types that the library can return.
+pub mod error;
+
 /// Handle extracting and installing downloaded product.
 pub mod install;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@ pub mod crc32;
 /// Handle extracting and installing downloaded product.
 pub mod install;
 
-/// Various output messages.
-pub mod messages;
-
 /// List of [HashiCorp](https://www.hashicorp.com/) products.
 pub mod products;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,6 @@ pub mod crc32;
 /// Handle extracting and installing downloaded product.
 pub mod install;
 
-/// List of [HashiCorp](https://www.hashicorp.com/) products.
-pub mod products;
-
 /// Handle drawing progress bars during download and install.
 pub mod progressbar;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use hcdl::{
     client,
     install,
-    products,
     shasums,
 };
 use hcdl::tmpfile::TmpFile;
@@ -17,6 +16,7 @@ use std::process::exit;
 
 mod cli;
 mod messages;
+mod products;
 
 use messages::Messages;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,10 @@ use hcdl::{
 };
 use hcdl::messages::Messages;
 use hcdl::tmpfile::TmpFile;
-use std::path::PathBuf;
+use std::path::{
+    Path,
+    PathBuf,
+};
 use std::process::exit;
 
 mod cli;
@@ -182,7 +185,12 @@ async fn main() -> Result<()> {
     messages.unzipping(filename, &bin_dir);
 
     let mut zip_handle = tmpfile.handle()?;
-    match install::install(&messages, &mut zip_handle, &bin_dir) {
+
+    let extract_message = |filename: &Path, path: &Path| {
+        messages.extracting_file(filename, path);
+    };
+
+    match install::install(Some(&extract_message), &mut zip_handle, &bin_dir) {
         Ok(_)  => messages.installation_successful(),
         Err(e) => {
             messages.installation_failed(&e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use hcdl::{
     products,
     shasums,
 };
-use hcdl::messages::Messages;
 use hcdl::tmpfile::TmpFile;
 use std::path::{
     Path,
@@ -19,6 +18,9 @@ use std::path::{
 use std::process::exit;
 
 mod cli;
+mod messages;
+
+use messages::Messages;
 
 #[cfg(feature = "shell_completion")]
 use clap_complete::Shell;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,7 @@ use hcdl::{
     shasums,
 };
 use hcdl::tmpfile::TmpFile;
-use std::path::{
-    Path,
-    PathBuf,
-};
+use std::path::PathBuf;
 use std::process::exit;
 
 mod cli;
@@ -186,12 +183,14 @@ async fn main() -> Result<()> {
 
     let mut zip_handle = tmpfile.handle()?;
 
-    let extract_message = |filename: &Path, path: &Path| {
-        messages.extracting_file(filename, path);
-    };
+    match install::install(&mut zip_handle, &bin_dir) {
+        Ok(extracted_files) => {
+            for file in extracted_files {
+                messages.extracted_file(&file, &bin_dir);
+            }
 
-    match install::install(Some(&extract_message), &mut zip_handle, &bin_dir) {
-        Ok(_)  => messages.installation_successful(),
+            messages.installation_successful();
+        },
         Err(e) => {
             messages.installation_failed(&e);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 //! hcdl: Easily update Hashicorp tools
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::redundant_field_names)]
 use anyhow::Result;
 use hcdl::{
     client,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,28 +4,25 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::redundant_field_names)]
 use anyhow::Result;
+use hcdl::{
+    client,
+    install,
+    products,
+    shasums,
+};
+use hcdl::messages::Messages;
+use hcdl::tmpfile::TmpFile;
 use std::path::PathBuf;
 use std::process::exit;
 
 mod cli;
-mod client;
-mod crc32;
-mod install;
-mod messages;
-mod products;
-mod progressbar;
-mod shasums;
-mod signature;
-mod tmpfile;
-
-use messages::Messages;
-use tmpfile::TmpFile;
 
 #[cfg(feature = "shell_completion")]
 use clap_complete::Shell;
 
 const LATEST: &str = "latest";
 
+#[allow(clippy::too_many_lines)]
 #[tokio::main]
 async fn main() -> Result<()> {
     let matches  = cli::parse_args();

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,8 +1,10 @@
 // Messages output by other parts of the program
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
-use anyhow::Error;
-use hcdl::error::InstallError;
+use hcdl::error::{
+    InstallError,
+    SignatureError,
+};
 use std::path::Path;
 
 /// Handler for the various message we need to output.
@@ -126,7 +128,7 @@ impl Messages {
     }
 
     /// Output when signature verification has failed.
-    pub fn signature_verification_failed(&self, error: &Error) {
+    pub fn signature_verification_failed(&self, error: &SignatureError) {
         let msg = format!("Verification failed, error: {error}");
 
         self.stderr(&msg);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,7 +15,7 @@ impl Messages {
     #[must_use]
     pub fn new(quiet: bool) -> Self {
         Self {
-            quiet: quiet,
+            quiet,
         }
     }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -60,9 +60,9 @@ impl Messages {
     }
 
     /// Output when a file is being extracted.
-    pub fn extracting_file(&self, filename: &Path, dest: &Path) {
+    pub fn extracted_file(&self, filename: &Path, dest: &Path) {
         let msg = format!(
-            "-> Extracting '{filename}' to '{dest}'...",
+            "-> Extracted '{filename}' to '{dest}'...",
             filename = filename.display(),
             dest = dest.display(),
         );

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
 use anyhow::Error;
+use hcdl::error::InstallError;
 use std::path::Path;
 
 /// Handler for the various message we need to output.
@@ -79,7 +80,7 @@ impl Messages {
     }
 
     /// Output when a product installation has failed.
-    pub fn installation_failed(&self, error: &Error) {
+    pub fn installation_failed(&self, error: &InstallError) {
         let msg = format!("Installation failed with error: {error}");
 
         self.stderr(&msg);

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -4,11 +4,15 @@
 use anyhow::Error;
 use std::path::Path;
 
+/// Handler for the various message we need to output.
 pub struct Messages {
     quiet: bool,
 }
 
 impl Messages {
+    /// Crates a new [`Messages`] handler. If `quiet` is set to `true`, no
+    /// output will be given.
+    #[must_use]
     pub fn new(quiet: bool) -> Self {
         Self {
             quiet: quiet,
@@ -21,34 +25,41 @@ impl Messages {
         }
     }
 
+    #[allow(clippy::unused_self)]
     fn stderr(&self, msg: &str) {
         eprintln!("{msg}");
     }
 
+    /// Output when the checksum of the file is bad.
     pub fn checksum_bad(&self, filename: &str) {
         let msg = format!("SHA256 of {filename} did not match.");
 
         self.stderr(&msg);
     }
 
+    /// Output when the checksum of the file is good.
     pub fn checksum_ok(&self, filename: &str) {
         let msg = format!("SHA256 of {filename} OK.");
 
         self.stdout(&msg);
     }
 
+    /// Output when the download of a file is starting.
     pub fn downloading(&self, filename: &str) {
         let msg = format!("Downloading {filename}...");
 
         self.stdout(&msg);
     }
 
+    /// Output when download only mode is used to indicate the downloaded file
+    /// will not be deleted.
     pub fn download_only(&self, filename: &str) {
         let msg = format!("Download only mode, keeping {filename}.");
 
         self.stdout(&msg);
     }
 
+    /// Output when a file is being extracted.
     pub fn extracting_file(&self, filename: &Path, dest: &Path) {
         let msg = format!(
             "-> Extracting '{filename}' to '{dest}'...",
@@ -59,34 +70,41 @@ impl Messages {
         self.stdout(&msg);
     }
 
+    /// Output when we can't find a product build for the specified OS and
+    /// architecture.
     pub fn find_build_failed(&self, os: &str, arch: &str) {
         let msg = format!("Could not find build for {os}-{arch}");
 
         self.stderr(&msg);
     }
 
+    /// Output when a product installation has failed.
     pub fn installation_failed(&self, error: &Error) {
         let msg = format!("Installation failed with error: {error}");
 
         self.stderr(&msg);
     }
 
+    /// Output when a product installation was successful.
     pub fn installation_successful(&self) {
         self.stdout("Installation successful.");
     }
 
+    /// Output when a zipfile has been kept instead of being deleted.
     pub fn keep_zipfile(&self, filename: &str) {
         let msg = format!("Keeping zipfile {filename} in current directory.");
 
         self.stdout(&msg);
     }
 
+    /// Output when checking for the latest product version.
     pub fn latest_version(&self, latest: &str) {
         let msg = format!("Latest version: {latest}");
 
         self.stdout(&msg);
     }
 
+    /// Output when the product list was requested.
     pub fn list_products(&self, products: &[&str]) {
         let msg = format!(
             "Products: {products}",
@@ -96,6 +114,8 @@ impl Messages {
         self.stdout(&msg);
     }
 
+    /// Output when an installation is attempted for a product OS that doesn't
+    /// match the current OS.
     pub fn os_mismatch(&self, os: &str, requested: &str) {
         let msg = format!(
             "Product downloaded for different OS, {os} != {requested}",
@@ -104,18 +124,21 @@ impl Messages {
         self.stdout(&msg);
     }
 
+    /// Output when signature verification has failed.
     pub fn signature_verification_failed(&self, error: &Error) {
         let msg = format!("Verification failed, error: {error}");
 
         self.stderr(&msg);
     }
 
+    /// Output when signature verification is successful.
     pub fn signature_verification_success(&self, signature: &str) {
         let msg = format!("Verified against {signature}.");
 
         self.stdout(&msg);
     }
 
+    /// Output when installation of the product is skipped.
     pub fn skipped_install(&self, filename: &str) {
         let msg = format!(
             "Skipping install and keeping zipfile '{filename}' in current \
@@ -125,6 +148,7 @@ impl Messages {
         self.stdout(&msg);
     }
 
+    /// Output when content is being unzipped.
     pub fn unzipping(&self, zipfile: &str, dest: &Path) {
         let msg = format!(
             "Unzipping contents of '{zipfile}' to '{dest}'",
@@ -134,6 +158,7 @@ impl Messages {
         self.stdout(&msg);
     }
 
+    /// Output when a signature is being verified.
     pub fn verifying_signature(&self, shasums: &str) {
         let msg = format!(
             "Downloading and verifying signature of {shasums}...",

--- a/src/products.rs
+++ b/src/products.rs
@@ -2,6 +2,8 @@
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
 
+/// A list of [HashiCorp](https://www.hashicorp.com/) products that this crate
+/// can download.
 pub const PRODUCTS_LIST: &[&str] = &[
     "consul",
     "nomad",

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -31,6 +31,7 @@ const PROGRESS_TEMPLATE_NO_COLOR: &str = concat!(
     " {msg}",
 );
 
+/// A builder for [`ProgressBar`].
 #[derive(Default)]
 pub struct ProgressBarBuilder {
     no_color: bool,
@@ -39,25 +40,36 @@ pub struct ProgressBarBuilder {
 }
 
 impl ProgressBarBuilder {
+    /// Create a new [`ProgressBarBuilder`] with the default settings.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Disable the [`ProgressBar`] colours.
+    #[must_use]
     pub fn no_color(mut self, no_color: bool) -> Self {
         self.no_color = no_color;
         self
     }
 
+    /// Set quiet mode on the [`ProgressBar`], no output will be drawn.
+    #[must_use]
     pub fn quiet(mut self, quiet: bool) -> Self {
         self.quiet = quiet;
         self
     }
 
+    /// Set the size of the [`ProgressBar`].
+    #[must_use]
     pub fn size(mut self, size: Option<u64>) -> Self {
         self.size = size;
         self
     }
 
+    /// Build and return the [`ProgressBar`].
+    #[allow(clippy::missing_panics_doc)]
+    #[must_use]
     pub fn build(self) -> ProgressBar {
         // No progress bar for quiet mode.
         if self.quiet {
@@ -79,6 +91,8 @@ impl ProgressBarBuilder {
                 PROGRESS_TEMPLATE
             };
 
+            // We shouldn't ever panic here, since our progress bar templates
+            // are not user provided, we've tested them.
             let style = ProgressStyle::default_bar()
                 .template(template)
                 .unwrap()
@@ -107,15 +121,18 @@ impl ProgressBarBuilder {
     }
 }
 
+/// A wrapper for an [`indicatif::ProgressBar`].
 pub struct ProgressBar {
     bar: indicatif::ProgressBar,
 }
 
 impl ProgressBar {
+    /// Wraps the given writer with the [`ProgressBar`].
     pub fn wrap_write<W: Write>(&self, writer: W) -> ProgressBarIter<W> {
         self.bar.wrap_write(writer)
     }
 
+    /// Flags the [`ProgressBar`] as finished and prints a final message.
     pub fn finished(&self) {
         self.bar.finish_with_message(PROGRESS_FINISHED_MSG);
     }

--- a/src/shasums.rs
+++ b/src/shasums.rs
@@ -172,7 +172,7 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            format!("Couldn't find shasum for {test_data_path}"),
+            format!("couldn't find shasum for {test_data_path}"),
         );
     }
 

--- a/src/shasums.rs
+++ b/src/shasums.rs
@@ -1,7 +1,7 @@
 // shasums: Handle checking of files against shasums
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
-use super::TmpFile;
+use crate::tmpfile::TmpFile;
 use anyhow::{
     anyhow,
     Result,
@@ -13,17 +13,24 @@ use sha2::{
 use std::collections::HashMap;
 use std::io;
 
+/// This enum represents the outcome of shasum verification.
 #[derive(Debug, Eq, PartialEq)]
 pub enum Checksum {
-    OK,
+    /// Sha checksum did not verify.
     Bad,
+
+    /// Sha checksum verified correctly.
+    OK,
 }
 
+/// [`Shasums`] represents a downloaded shasum file.
 pub struct Shasums {
     content: String,
 }
 
 impl Shasums {
+    /// Create a new [`Shasums`] from the given shasum content.
+    #[must_use]
     pub fn new(shasums: String) -> Self {
         Self {
             content: shasums,
@@ -51,7 +58,15 @@ impl Shasums {
         hash
     }
 
-    // Check the shasum of the specified file
+    /// Check the shasum of the given `tmpfile` against our [`Shasums`]
+    /// content.
+    ///
+    /// # Errors
+    ///
+    /// Can error if:
+    ///   - Failing to find the shasum for the `tmpfile` filename
+    ///   - Failing to obtain a handle for the `tmpfile`
+    ///   - Failing to hash the file content
     pub fn check(&self, tmpfile: &mut TmpFile) -> Result<Checksum> {
         let filename = tmpfile.filename();
         let shasum   = self.shasum(filename)
@@ -74,7 +89,8 @@ impl Shasums {
         Ok(res)
     }
 
-    // Return a reference to the shasums
+    /// Return a reference to the [`Shasums`] content.
+    #[must_use]
     pub fn content(&self) -> &str {
         &self.content
     }

--- a/src/shasums.rs
+++ b/src/shasums.rs
@@ -70,7 +70,7 @@ impl Shasums {
     pub fn check(&self, tmpfile: &mut TmpFile) -> Result<Checksum> {
         let filename = tmpfile.filename();
         let shasum   = self.shasum(filename)
-            .ok_or_else(|| anyhow!("Couldn't find shasum for {}", filename))?;
+            .ok_or_else(|| anyhow!("Couldn't find shasum for {filename}"))?;
 
         let mut file   = tmpfile.handle()?;
         let mut hasher = Sha256::new();
@@ -169,7 +169,7 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            format!("Couldn't find shasum for {}", test_data_path),
+            format!("Couldn't find shasum for {test_data_path}"),
         );
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -152,8 +152,8 @@ fn get_public_key_path() -> Result<PathBuf> {
         // Ensure that the data dir exists
         if !path.exists() || !path.is_dir() {
             let msg = anyhow!(
-                "Data directory {} does not exist or is not a directory",
-                path.display(),
+                "Data directory {dir} does not exist or is not a directory",
+                dir = path.display(),
             );
 
             return Err(msg);
@@ -165,9 +165,9 @@ fn get_public_key_path() -> Result<PathBuf> {
         // Ensure that the GPG key exists
         if !path.exists() || !path.is_file() {
             let msg = format!(
-                "GPG key file {} does not exist or it not a file.\n\
+                "GPG key file {path} does not exist or it not a file.\n\
                  Check https://www.hashicorp.com/security to find the GPG key",
-                path.display(),
+                path = path.display(),
             );
 
             return Err(anyhow!(msg));

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -120,7 +120,7 @@ impl Signature {
 // Read a file's content into a String
 #[cfg(any(test, not(feature = "embed_gpg_key")))]
 fn read_file_content(path: &PathBuf) -> Result<String, SignatureError> {
-    let file         = File::open(&path)?;
+    let file         = File::open(path)?;
     let mut reader   = BufReader::new(file);
     let mut contents = String::new();
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -110,7 +110,8 @@ impl Signature {
         }
 
         // One last attempt, check against the main public key.
-        self.signature.verify(&self.public_key, shasums)?;
+        self.signature.verify(&self.public_key, shasums)
+            .map_err(|_err| SignatureError::Verification)?;
 
         Ok(())
     }
@@ -192,7 +193,7 @@ mod tests {
     use std::path::Path;
 
     // Read a file's contents into Bytes
-    fn read_file_bytes(path: &PathBuf) -> Result<Bytes> {
+    fn read_file_bytes(path: &PathBuf) -> Result<Bytes, SignatureError> {
         let file         = File::open(&path)?;
         let mut reader   = BufReader::new(file);
         let mut contents = Vec::new();
@@ -316,7 +317,7 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Couldn't verify signature",
+            "couldn't verify signature",
         )
     }
 
@@ -367,7 +368,7 @@ mod tests {
 
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Couldn't verify signature",
+            "couldn't verify signature",
         )
     }
 }

--- a/src/tmpfile.rs
+++ b/src/tmpfile.rs
@@ -13,13 +13,18 @@ use tempfile::NamedTempFile;
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::OpenOptionsExt;
 
+/// Wrapper for a [`tempfile::NamedTempFile`].
 pub struct TmpFile {
     tmpfile:  NamedTempFile,
     filename: String,
 }
 
 impl TmpFile {
-    // Make a new TmpFile for filename
+    /// Make a new [`TmpFile`] for filename.
+    ///
+    /// # Errors
+    ///
+    /// Can error if unable to create a [`NamedTempFile`].
     pub fn new(filename: &str) -> Result<Self> {
         let tmp = Self {
             filename: filename.to_owned(),
@@ -29,19 +34,31 @@ impl TmpFile {
         Ok(tmp)
     }
 
-    // Return the tmpfile filename
+    /// Return the tmpfile filename
+    #[must_use]
     pub fn filename(&self) -> &str {
         &self.filename
     }
 
-    // Return a handle that has been rewound to 0
+    /// Return a [`NamedTempFile`] handle that has been rewound to 0.
+    ///
+    /// # Errors
+    ///
+    /// Can error if seeking to the beginning of the `tmpfile` fails.
     pub fn handle(&mut self) -> Result<&mut NamedTempFile> {
         self.tmpfile.seek(SeekFrom::Start(0))?;
 
         Ok(&mut self.tmpfile)
     }
 
-    // Persist the file into our current directory as self.filename
+    /// Persist the file into our current directory as self.filename
+    ///
+    /// # Errors
+    ///
+    /// Can error under various common IO issues such as:
+    ///   - Failure to open file for writing
+    ///   - Attempting to get the file handle for the `tmpfile`
+    ///   - Issues while writing to the `tmpfile`
     pub fn persist(&mut self) -> Result<()> {
         let dest        = Path::new(&self.filename);
         let mut options = OpenOptions::new();

--- a/src/tmpfile.rs
+++ b/src/tmpfile.rs
@@ -1,5 +1,5 @@
 // Handles a tmpfile for downloading
-use anyhow::Result;
+use super::error::TmpFileError;
 use std::fs::OpenOptions;
 use std::io::{
     self,
@@ -25,7 +25,7 @@ impl TmpFile {
     /// # Errors
     ///
     /// Can error if unable to create a [`NamedTempFile`].
-    pub fn new(filename: &str) -> Result<Self> {
+    pub fn new(filename: &str) -> Result<Self, TmpFileError> {
         let tmp = Self {
             filename: filename.to_owned(),
             tmpfile:  NamedTempFile::new()?,
@@ -45,7 +45,7 @@ impl TmpFile {
     /// # Errors
     ///
     /// Can error if seeking to the beginning of the `tmpfile` fails.
-    pub fn handle(&mut self) -> Result<&mut NamedTempFile> {
+    pub fn handle(&mut self) -> Result<&mut NamedTempFile, TmpFileError> {
         self.tmpfile.seek(SeekFrom::Start(0))?;
 
         Ok(&mut self.tmpfile)
@@ -59,7 +59,7 @@ impl TmpFile {
     ///   - Failure to open file for writing
     ///   - Attempting to get the file handle for the `tmpfile`
     ///   - Issues while writing to the `tmpfile`
-    pub fn persist(&mut self) -> Result<()> {
+    pub fn persist(&mut self) -> Result<(), TmpFileError> {
         let dest        = Path::new(&self.filename);
         let mut options = OpenOptions::new();
 


### PR DESCRIPTION
Related to issue #7.

This PR moves various functionality under `lib.rs`, potentially allowing the crate to be used as a library, with the crate bin being a consumer of that library.

The exposed API is unstable and likely to move around quite a bit while things are being documented.

The documentation is not currently the best. I haven’t had to document a library yet, and I’m very aware that it’s lacking. I need to review some other library docs to help me decide what and how to write about various things. I also need to come up with some doctests.